### PR TITLE
Drop inclusion of zend_ts_hash.h

### DIFF
--- a/php_uv.h
+++ b/php_uv.h
@@ -54,7 +54,6 @@ typedef struct {
 #include <Zend/zend_extensions.h>
 #include <Zend/zend_globals.h>
 #include <Zend/zend_hash.h>
-#include <Zend/zend_ts_hash.h>
 #include <Zend/zend_interfaces.h>
 #include <Zend/zend_list.h>
 #include <Zend/zend_object_handlers.h>


### PR DESCRIPTION
File no longer exists as per https://github.com/php/php-src/commit/00c668a15d699e9a463d7feec9d4f927cb7e4105